### PR TITLE
soong: java: Specify larger heap size for metalava

### DIFF
--- a/java/droiddoc.go
+++ b/java/droiddoc.go
@@ -1474,6 +1474,7 @@ func metalavaCmd(ctx android.ModuleContext, rule *android.RuleBuilder, javaVersi
 
 	cmd.BuiltTool(ctx, "metalava").
 		Flag(config.JavacVmFlags).
+		Flag("-J-Xmx6114m").
 		FlagWithArg("-encoding ", "UTF-8").
 		FlagWithArg("-source ", javaVersion.String()).
 		FlagWithRspFileInputList("@", srcs).


### PR DESCRIPTION
filiprrs: This is needed on systems with 8GB physical ram.
Compiling using a single job is recommended.

Gegham Zakaryan <zakaryan.200@outlook.com>: adapt for R

Change-Id: I5093dcdbe384fd33f0dc0fd9b89c91f8f9fa19fd